### PR TITLE
add home directory for masswalletcli

### DIFF
--- a/cmd/masswalletcli/cmd/config.go
+++ b/cmd/masswalletcli/cmd/config.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"os/user"
+	"path/filepath"
+	"strings"
+
 	"massnet.org/mass-wallet/logging"
 
 	"github.com/spf13/viper"
@@ -10,10 +14,11 @@ const (
 	defaultServer      = "https://localhost:9686"
 	defaultLogFilename = "clilog"
 	defaultLogLevel    = "info"
+	defaultMassHomeDir = ".massnet"
 	defaultLogDir      = "./logs"
 	rpcCert            = "./conf/cert.crt"
 	rpcKey             = "./conf/cert.key"
-	configFile         = "./cli-config.json"
+	configFile         = "./conf/masswalletcli.json"
 )
 
 var (
@@ -24,6 +29,8 @@ type Config struct {
 	Server   string `json:"server"`
 	LogDir   string `json:"log_dir"`
 	LogLevel string `json:"log_level"`
+	RPCCert  string `json:"rpc_cert"`
+	RPCKey   string `json:"rpc_key"`
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -31,7 +38,7 @@ func initConfig() {
 	// viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
-	viper.SetConfigFile(configFile)
+	viper.SetConfigFile(ensureMassAbsPath(configFile))
 	if err := viper.ReadInConfig(); err != nil {
 		panic(err)
 	}
@@ -52,5 +59,39 @@ func initConfig() {
 		config.LogLevel = defaultLogLevel
 	}
 
+	config.RPCCert = viper.GetString("rpc_cert")
+	if config.RPCCert == "" {
+		config.RPCCert = rpcCert
+	}
+
+	config.RPCKey = viper.GetString("rpc_key")
+	if config.RPCKey == "" {
+		config.RPCKey = rpcKey
+	}
+
+	config.LogDir = ensureMassAbsPath(config.LogDir)
+	config.RPCCert = ensureMassAbsPath(config.RPCCert)
+	config.RPCKey = ensureMassAbsPath(config.RPCKey)
+
 	logging.Init(config.LogDir, defaultLogFilename, config.LogLevel, 1, false)
+}
+
+// ensureMassAbsPath to ensure the configured path is absolute
+func ensureMassAbsPath(configuredPath string) string {
+	if configuredPath == "" {
+		return ""
+	}
+	if strings.Index(configuredPath, "/") == 0 {
+		return configuredPath
+	}
+	usr, err := user.Current()
+	if err != nil {
+		return configuredPath
+	}
+	if strings.Index(configuredPath, ".") == 0 {
+		configuredPath = strings.TrimPrefix(configuredPath, ".")
+	}
+	subPaths := []string{usr.HomeDir, defaultMassHomeDir}
+	subPaths = append(subPaths, strings.Split(configuredPath, "/")...)
+	return filepath.Join(subPaths...)
 }

--- a/cmd/masswalletcli/cmd/util.go
+++ b/cmd/masswalletcli/cmd/util.go
@@ -64,7 +64,7 @@ func initClient() {
 
 	switch {
 	case u.Scheme == "https":
-		cert, err := tls.LoadX509KeyPair(rpcCert, rpcKey)
+		cert, err := tls.LoadX509KeyPair(config.RPCCert, config.RPCKey)
 		if err != nil {
 			logging.VPrint(logging.FATAL, "failed to load certificate", logging.LogFormat{"err": err})
 		}


### PR DESCRIPTION
In using `masswalletcli`, it is found that the relevant logs, configuration files and certificates are the current working directory of the read program. I hope to give it a fixed directory! (in user's home directory `$HOME/.massnet`)